### PR TITLE
docs (readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,4 +504,4 @@ This repository release does not itself provide a public-facing generative AI se
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OpenGalaxea/GalaxeaVLA&type=date&legend=top-left)](https://www.star-history.com/#OpenGalaxea/GalaxeaVLA&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OpenGalaxea/GalaxeaVLA&type=date&legend=top-left)](https://star-history.dera.page/#OpenGalaxea/GalaxeaVLA&type=date&legend=top-left)

--- a/README_zh.md
+++ b/README_zh.md
@@ -498,4 +498,4 @@ G0.5 使用 Qwen3.5 作为预训练 VLM 骨干模型，并包含 Qwen3.5 派生�
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OpenGalaxea/GalaxeaVLA&type=date&legend=top-left)](https://www.star-history.com/#OpenGalaxea/GalaxeaVLA&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OpenGalaxea/GalaxeaVLA&type=date&legend=top-left)](https://star-history.dera.page/#OpenGalaxea/GalaxeaVLA&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart on the README is currently broken and shows no data. The old endpoint relies on the GitHub stargazer API, which now rate-limits those requests, so the chart never renders. This change points the chart (and its link) at a working mirror in both README.md and README_zh.md.